### PR TITLE
Disable TrailingCommaInArguments

### DIFF
--- a/ruby-rubocop.yml
+++ b/ruby-rubocop.yml
@@ -1072,8 +1072,7 @@ Style/TrailingCommaInHashLiteral:
 Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in parameter lists.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
-  EnforcedStyleForMultiline: consistent_comma
-  Enabled: true
+  Enabled: false
 
 Layout/TrailingWhitespace:
   Description: 'Avoid trailing whitespace.'


### PR DESCRIPTION
Ok, this doesn't behave like I thought it would.
It's making perfectly fine readable code look worse.
It's changing things like this:
```
Updates.add_update(game, {
  action: 'tick',
  currentPlayer: game[:currentHand][:public][:currentPlayer].dup,
}),
```
to
```
Updates.add_update(game, {
  action: 'tick',
  currentPlayer: game[:currentHand][:public][:currentPlayer].dup,
},),
```